### PR TITLE
Move the nested collate function into a separate callable object.

### DIFF
--- a/torch_geometric/data/dataloader.py
+++ b/torch_geometric/data/dataloader.py
@@ -5,6 +5,37 @@ from torch_geometric.data import Data, Batch
 from torch._six import container_abcs, string_classes, int_classes
 
 
+class Collater(object):
+
+    def __init__(self, follow_batch):
+        self.follow_batch = follow_batch
+
+    def collate(self, batch):
+        elem = batch[0]
+        if isinstance(elem, Data):
+            return Batch.from_data_list(batch, self.follow_batch)
+        elif isinstance(elem, torch.Tensor):
+            return default_collate(batch)
+        elif isinstance(elem, float):
+            return torch.tensor(batch, dtype=torch.float)
+        elif isinstance(elem, int_classes):
+            return torch.tensor(batch)
+        elif isinstance(elem, string_classes):
+            return batch
+        elif isinstance(elem, container_abcs.Mapping):
+            return {key: collate([d[key] for d in batch]) for key in elem}
+        elif isinstance(elem, tuple) and hasattr(elem, '_fields'):
+            return type(elem)(*(collate(s) for s in zip(*batch)))
+        elif isinstance(elem, container_abcs.Sequence):
+            return [collate(s) for s in zip(*batch)]
+
+        raise TypeError('DataLoader found invalid type: {}'.format(
+            type(elem)))
+
+    def __call__(self, batch):
+        return self.collate(batch)
+
+    
 class DataLoader(torch.utils.data.DataLoader):
     r"""Data loader which merges data objects from a
     :class:`torch_geometric.data.dataset` to a mini-batch.
@@ -20,31 +51,9 @@ class DataLoader(torch.utils.data.DataLoader):
     """
     def __init__(self, dataset, batch_size=1, shuffle=False, follow_batch=[],
                  **kwargs):
-        def collate(batch):
-            elem = batch[0]
-            if isinstance(elem, Data):
-                return Batch.from_data_list(batch, follow_batch)
-            elif isinstance(elem, torch.Tensor):
-                return default_collate(batch)
-            elif isinstance(elem, float):
-                return torch.tensor(batch, dtype=torch.float)
-            elif isinstance(elem, int_classes):
-                return torch.tensor(batch)
-            elif isinstance(elem, string_classes):
-                return batch
-            elif isinstance(elem, container_abcs.Mapping):
-                return {key: collate([d[key] for d in batch]) for key in elem}
-            elif isinstance(elem, tuple) and hasattr(elem, '_fields'):
-                return type(elem)(*(collate(s) for s in zip(*batch)))
-            elif isinstance(elem, container_abcs.Sequence):
-                return [collate(s) for s in zip(*batch)]
-
-            raise TypeError('DataLoader found invalid type: {}'.format(
-                type(elem)))
-
         super(DataLoader,
               self).__init__(dataset, batch_size, shuffle,
-                             collate_fn=lambda batch: collate(batch), **kwargs)
+                             collate_fn=Collater(follow_batch), **kwargs)
 
 
 class DataListLoader(torch.utils.data.DataLoader):
@@ -68,7 +77,14 @@ class DataListLoader(torch.utils.data.DataLoader):
               self).__init__(dataset, batch_size, shuffle,
                              collate_fn=lambda data_list: data_list, **kwargs)
 
+        
+def dense_collate(data_list):
+    batch = Batch()
+    for key in data_list[0].keys:
+        batch[key] = default_collate([d[key] for d in data_list])
+    return batch
 
+        
 class DenseDataLoader(torch.utils.data.DataLoader):
     r"""Data loader which merges data objects from a
     :class:`torch_geometric.data.dataset` to a mini-batch.
@@ -88,12 +104,6 @@ class DenseDataLoader(torch.utils.data.DataLoader):
             reshuffled at every epoch (default: :obj:`False`)
     """
     def __init__(self, dataset, batch_size=1, shuffle=False, **kwargs):
-        def dense_collate(data_list):
-            batch = Batch()
-            for key in data_list[0].keys:
-                batch[key] = default_collate([d[key] for d in data_list])
-            return batch
-
         super(DenseDataLoader,
               self).__init__(dataset, batch_size, shuffle,
                              collate_fn=dense_collate, **kwargs)


### PR DESCRIPTION
The original nested functions `collate` and `dense_collate` cause problems on Windows because subprocess (on Win) uses pickle for serialization when multiprocessing. Lambda and nested functions cannot be pickled on Windows. Therefore, `dense_collate` is moved out of `DenseDataLoader`  and `collate` is turned into a callable object `Collater` because it needs a member.